### PR TITLE
Added ability to override a dynamic route in annotation.

### DIFF
--- a/kleuth-integration-tests/build.gradle.kts
+++ b/kleuth-integration-tests/build.gradle.kts
@@ -25,7 +25,7 @@ dependencies {
 }
 
 group = "io.alienhead"
-version = "0.0.1-SNAPSHOT"
+version = "0.1.0-SNAPSHOT"
 
 java.sourceCompatibility = JavaVersion.VERSION_1_8
 

--- a/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/everything/api/test/override/other/GetWithOverriddenPathEverything.kt
+++ b/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/everything/api/test/override/other/GetWithOverriddenPathEverything.kt
@@ -1,0 +1,13 @@
+package io.alienhead.kleuth.everything.api.test.override.other
+
+import io.alienhead.kleuth.annotations.RouteController
+import io.alienhead.kleuth.resource.TestResource
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+
+@RouteController("/overridden-path/{testId}")
+class GetWithOverriddenPathEverything {
+  fun handler(@PathVariable testId: String): ResponseEntity<TestResource> {
+    return ResponseEntity.ok(TestResource("testId: $testId"))
+  }
+}

--- a/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/everything/api/test/override/other/GetWithOverriddenPathOtherEverything.kt
+++ b/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/everything/api/test/override/other/GetWithOverriddenPathOtherEverything.kt
@@ -1,0 +1,15 @@
+package io.alienhead.kleuth.everything.api.test.override.other
+
+import io.alienhead.kleuth.annotations.Route
+import io.alienhead.kleuth.resource.TestResource
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RestController
+
+@Route("/overridden-path/{testId}/other")
+@RestController
+class GetWithOverriddenPathOtherEverything {
+  fun handler(@PathVariable testId: String): ResponseEntity<TestResource> {
+    return ResponseEntity.ok(TestResource("testId: $testId"))
+  }
+}

--- a/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/overridepath/api/test/GetWithOverriddenPath.kt
+++ b/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/overridepath/api/test/GetWithOverriddenPath.kt
@@ -1,0 +1,13 @@
+package io.alienhead.kleuth.overridepath.api.test
+
+import io.alienhead.kleuth.annotations.RouteController
+import io.alienhead.kleuth.resource.TestResource
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+
+@RouteController("/overridden-path/{testId}")
+class GetWithOverriddenPath {
+  fun handler(@PathVariable testId: String): ResponseEntity<TestResource> {
+    return ResponseEntity.ok(TestResource("testId: $testId"))
+  }
+}

--- a/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/overridepath/api/test/other/GetWithOverriddenPathOther.kt
+++ b/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/overridepath/api/test/other/GetWithOverriddenPathOther.kt
@@ -1,0 +1,15 @@
+package io.alienhead.kleuth.overridepath.api.test.other
+
+import io.alienhead.kleuth.annotations.Route
+import io.alienhead.kleuth.resource.TestResource
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RestController
+
+@Route("/overridden-path/{testId}/other")
+@RestController
+class GetWithOverriddenPathOther {
+  fun handler(@PathVariable testId: String): ResponseEntity<TestResource> {
+    return ResponseEntity.ok(TestResource("testId: $testId"))
+  }
+}

--- a/kleuth-integration-tests/src/main/resources/application-overridepath.properties
+++ b/kleuth-integration-tests/src/main/resources/application-overridepath.properties
@@ -1,0 +1,1 @@
+kleuth.core.pathToPackage=io/alienhead/kleuth/overridepath/api

--- a/kleuth-integration-tests/src/test/kotlin/io/alienhead/kleuth/everything/api/test/EverythingTests.kt
+++ b/kleuth-integration-tests/src/test/kotlin/io/alienhead/kleuth/everything/api/test/EverythingTests.kt
@@ -119,6 +119,28 @@ class EverythingTests(mvc: MockMvc) : DescribeSpec() {
             .andExpect(jsonPath("$.member", `is`("test")))
         }
       }
+
+      describe("/test/override") {
+        it("should map get request to handler when path is overridden in @RouteController") {
+          mvc.perform(
+            get("/overridden-path/{testId}", "1234")
+              .contentType(MediaType.APPLICATION_JSON)
+          )
+            .andExpect(status().isOk)
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.member", `is`("testId: 1234")))
+        }
+
+        it("should map get request to handler when path is overridden in @Route") {
+          mvc.perform(
+            get("/overridden-path/{testId}/other", "1234")
+              .contentType(MediaType.APPLICATION_JSON)
+          )
+            .andExpect(status().isOk)
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.member", `is`("testId: 1234")))
+        }
+      }
     }
   }
 }

--- a/kleuth-integration-tests/src/test/kotlin/io/alienhead/kleuth/overridepath/api/test/OverridePathTests.kt
+++ b/kleuth-integration-tests/src/test/kotlin/io/alienhead/kleuth/overridepath/api/test/OverridePathTests.kt
@@ -1,0 +1,50 @@
+package io.alienhead.kleuth.overridepath.api.test
+
+import io.kotest.core.listeners.TestListener
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.spring.SpringListener
+import org.hamcrest.CoreMatchers.`is`
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.http.MediaType
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@SpringBootTest
+@ActiveProfiles("overridepath")
+@AutoConfigureMockMvc
+class OverridePathTests(mvc: MockMvc) : DescribeSpec() {
+  override fun listeners(): List<TestListener> {
+    return listOf(SpringListener)
+  }
+
+  init {
+    describe("given @RouteController with overridden path") {
+      it("should map request to handler") {
+        mvc.perform(
+          get("/overridden-path/{testId}", "1234")
+            .contentType(MediaType.APPLICATION_JSON)
+        )
+          .andExpect(status().isOk)
+          .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+          .andExpect(jsonPath("$.member", `is`("testId: 1234")))
+      }
+    }
+
+    describe("given @Route with overridden path") {
+      it("should map request to handler") {
+        mvc.perform(
+          get("/overridden-path/{testId}/other", "1234")
+            .contentType(MediaType.APPLICATION_JSON)
+        )
+          .andExpect(status().isOk)
+          .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+          .andExpect(jsonPath("$.member", `is`("testId: 1234")))
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Added

- Override dynamic path
  - If the dynamically assembled path would not match the expected path, a route can be provided in the `@Route` or `@RouteController` annotations.

### Changed

N/A

### Removed

N/A