### PR TITLE
Restructured mapping code.

### DIFF
--- a/kleuth-integration-tests/build.gradle.kts
+++ b/kleuth-integration-tests/build.gradle.kts
@@ -28,7 +28,7 @@ dependencies {
 }
 
 group = "io.alienhead"
-version = "0.6.0-SNAPSHOT"
+version = "0.7.0-SNAPSHOT"
 
 java.sourceCompatibility = JavaVersion.VERSION_1_8
 

--- a/kleuth-integration-tests/src/main/resources/application-local.properties
+++ b/kleuth-integration-tests/src/main/resources/application-local.properties
@@ -1,4 +1,4 @@
 spring.application.name=KleuthTestApplication
 
 # Uncomment and set "test" as the active spring profile to start the application locally
-# kleuth.core.pathToPackage=io/alienhead/kleuth/everything/api
+# kleuth.core.pathToRoot=io/alienhead/kleuth/routes/api

--- a/kleuth-integration-tests/src/main/resources/application-routes.properties
+++ b/kleuth-integration-tests/src/main/resources/application-routes.properties
@@ -1,1 +1,1 @@
-kleuth.core.pathToPackage=io/alienhead/kleuth/routes/api
+kleuth.core.pathToRoot=io/alienhead/kleuth/routes/api

--- a/kleuth/build.gradle.kts
+++ b/kleuth/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
 }
 
 group = "io.alienhead"
-version = "0.6.0-SNAPSHOT"
+version = "0.7.0-SNAPSHOT"
 
 java.sourceCompatibility = JavaVersion.VERSION_1_8
 

--- a/kleuth/src/main/kotlin/io/alienhead/kleuth/ParsingUtils.kt
+++ b/kleuth/src/main/kotlin/io/alienhead/kleuth/ParsingUtils.kt
@@ -6,6 +6,15 @@ import io.alienhead.kleuth.annotations.request.Post
 import io.alienhead.kleuth.annotations.request.Put
 import net.pearx.kasechange.toKebabCase
 import org.springframework.web.bind.annotation.RequestMethod
+import kotlin.reflect.KFunction
+import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.hasAnnotation
+
+internal fun KFunction<*>.hasRequestAnnotation() =
+  this.hasAnnotation<Get>() ||
+    this.hasAnnotation<Post>() ||
+    this.hasAnnotation<Put>() ||
+    this.hasAnnotation<Delete>()
 
 internal fun Annotation?.fromAnnotation(): RequestMethod? =
   when (this) {
@@ -32,6 +41,25 @@ internal fun String.ofRequestMethod(strictEquality: Boolean = false): RequestMet
 
     (strictEquality && this == method.toLowerCase()) || (this.startsWith(method) || this.endsWith(method))
   }
+}
+
+internal fun KFunction<*>.getProducesConsumes() =
+  this.findAnnotation<Get>()?.let { annotation ->
+    Pair(annotation.produces, annotation.consumes)
+  } ?: this.findAnnotation<Post>()?.let { annotation ->
+    Pair(annotation.produces, annotation.consumes)
+  } ?: this.findAnnotation<Put>()?.let { annotation ->
+    Pair(annotation.produces, annotation.consumes)
+  } ?: this.findAnnotation<Delete>()?.let { annotation ->
+    Pair(annotation.produces, annotation.consumes)
+  }
+
+internal fun List<String>.appendToPath(): String {
+  var path = ""
+  this.forEach { pathVariable ->
+    path += "/{$pathVariable}"
+  }
+  return path
 }
 
 internal fun String.toPath(className: String) = this.removeClassName(className).replacePackageSeparator()

--- a/kleuth/src/main/kotlin/io/alienhead/kleuth/PathCache.kt
+++ b/kleuth/src/main/kotlin/io/alienhead/kleuth/PathCache.kt
@@ -1,0 +1,66 @@
+package io.alienhead.kleuth
+
+import net.pearx.kasechange.toKebabCase
+import org.springframework.web.bind.annotation.PathVariable
+import kotlin.reflect.KFunction
+import kotlin.reflect.full.findAnnotation
+
+class PathCache(private val pathToRoot: String) {
+  private val pathCache = mutableListOf<PathInfo>()
+
+  internal fun getOrCache(originalPath: String, handlerFunction: KFunction<*>): String {
+    var setPath = originalPath
+    /*
+          Get all the names of path variables in the route handler.
+          Spring allows the user to specify a name or value instead of the parameter name for mapping purposes
+          so we have to check if those are set
+         */
+    val routePathVariables: List<String> = handlerFunction.parameters.mapNotNull { parameter ->
+      parameter.findAnnotation<PathVariable>()?.let { pathVariable ->
+        when {
+          pathVariable.name.isNotEmpty() -> pathVariable.name
+          pathVariable.value.isNotEmpty() -> pathVariable.value
+          else -> parameter.name
+        }
+      }
+    }
+
+    setPath = setPath.toKebabCase()
+
+    /*
+      Check if there is a path already for the original path (folder path)
+      that also includes the same path variables
+     */
+    val matchingPathInfo = pathCache.firstOrNull { pathInfo ->
+      setPath.contains(pathInfo.originalPath.toKebabCase()) && routePathVariables.containsAll(pathInfo.pathVariables)
+    }
+
+    if (matchingPathInfo != null) {
+      setPath = setPath.replace(matchingPathInfo.originalPath, matchingPathInfo.newPath)
+      // It's possible the user has more path variables than the matching cached path
+      val missingPathVariables = routePathVariables - matchingPathInfo.pathVariables
+
+      if (missingPathVariables.isNotEmpty()) {
+        // If there are any path variables not found in the matched info,
+        // then they must be appended to the path
+        setPath += missingPathVariables.appendToPath()
+
+        // This path must be cached since it has additional path variables
+        pathCache.add(PathInfo(matchingPathInfo.originalPath, setPath, routePathVariables))
+      } else {
+        // This route's path and path variables are the same as another so we do not cache again.
+        setPath = matchingPathInfo.newPath
+      }
+    } else {
+      // We did not find an existing path, so this one is new and must be cached.
+      val newPath = setPath + routePathVariables.appendToPath()
+
+      // if no matching path then this is a new path
+      pathCache.add(PathInfo(setPath, newPath, routePathVariables))
+
+      setPath = newPath
+    }
+
+    return setPath.removeRootPathFromPath(pathToRoot)
+  }
+}

--- a/kleuth/src/main/kotlin/io/alienhead/kleuth/PathInfo.kt
+++ b/kleuth/src/main/kotlin/io/alienhead/kleuth/PathInfo.kt
@@ -1,6 +1,6 @@
 package io.alienhead.kleuth
 
-data class PathInfo(
+internal data class PathInfo(
   val originalPath: String,
   val newPath: String,
   val pathVariables: List<String>

--- a/kleuth/src/main/kotlin/io/alienhead/kleuth/RouteHandler.kt
+++ b/kleuth/src/main/kotlin/io/alienhead/kleuth/RouteHandler.kt
@@ -1,6 +1,6 @@
 package io.alienhead.kleuth
 
-data class RouteHandler(
+internal data class RouteHandler(
   val handlerInstance: Any,
   var path: String
 )

--- a/kleuth/src/main/kotlin/io/alienhead/kleuth/RouteHandlerExtensions.kt
+++ b/kleuth/src/main/kotlin/io/alienhead/kleuth/RouteHandlerExtensions.kt
@@ -1,5 +1,6 @@
 package io.alienhead.kleuth
 
+import io.alienhead.kleuth.annotations.request.Delete
 import io.alienhead.kleuth.annotations.request.Get
 import io.alienhead.kleuth.annotations.request.Post
 import io.alienhead.kleuth.annotations.request.Put
@@ -11,17 +12,19 @@ import kotlin.reflect.full.hasAnnotation
 // sort by path alphabetically and number of path variables.
 // get first function named "handler" or that has a request method annotation.
 // count how many path variables it has
-fun List<RouteHandler>.sortRoutes(): List<RouteHandler> {
+internal fun List<RouteHandler>.sortRoutes(): List<RouteHandler> {
   return this.sortedWith(
     compareBy(
       { it.path },
       {
         it.handlerInstance::class.functions.first { function ->
           function.name == "handler" ||
+            function.name.ofRequestMethod(true) != null ||
             (
               function.hasAnnotation<Get>() ||
                 function.hasAnnotation<Post>() ||
-                function.hasAnnotation<Put>()
+                function.hasAnnotation<Put>() ||
+                function.hasAnnotation<Delete>()
               )
         }.parameters.filter { parameter ->
           parameter.findAnnotation<PathVariable>() != null
@@ -30,3 +33,11 @@ fun List<RouteHandler>.sortRoutes(): List<RouteHandler> {
     )
   )
 }
+
+internal fun Map<String, Any>.toRouteHandlers(filterPath: String) =
+  this.map {
+    RouteHandler(
+      it.value,
+      it.value::class.qualifiedName!!.toPath(it.value::class.simpleName!!)
+    )
+  }.filter { it.path.contains(filterPath) }

--- a/kleuth/src/main/kotlin/io/alienhead/kleuth/RouteMapper.kt
+++ b/kleuth/src/main/kotlin/io/alienhead/kleuth/RouteMapper.kt
@@ -2,27 +2,18 @@ package io.alienhead.kleuth
 
 import io.alienhead.kleuth.annotations.Route
 import io.alienhead.kleuth.annotations.RouteController
-import io.alienhead.kleuth.annotations.request.Delete
-import io.alienhead.kleuth.annotations.request.Get
-import io.alienhead.kleuth.annotations.request.Post
-import io.alienhead.kleuth.annotations.request.Put
 import io.alienhead.kleuth.config.KleuthProperties
-import net.pearx.kasechange.toKebabCase
 import org.slf4j.LoggerFactory
 import org.springframework.context.ApplicationContext
-import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
-import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RequestMethod
 import org.springframework.web.servlet.mvc.method.RequestMappingInfo
 import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping
 import java.lang.reflect.Method
+import java.time.Duration
+import java.time.LocalDateTime
 import javax.annotation.PostConstruct
-import kotlin.reflect.KFunction
 import kotlin.reflect.full.findAnnotation
 import kotlin.reflect.full.functions
-import kotlin.reflect.full.hasAnnotation
 import kotlin.reflect.jvm.javaMethod
 
 class RouteMapper(
@@ -31,225 +22,104 @@ class RouteMapper(
   private var properties: KleuthProperties = KleuthProperties()
 ) {
   private val logger = LoggerFactory.getLogger(RouteMapper::class.java)
-
-  private val pathCache = mutableListOf<PathInfo>()
-  private var routesReady = false
+  private val pathCache = PathCache(properties.pathToRoot)
 
   @PostConstruct
-  fun mapRoutes() {
-    // Ensure the user has set the path to package property
-    if (properties.pathToPackage.isEmpty()) return
-
-    if (properties.health.enabled) {
-      logger.info("Launching health endpoint at /${properties.health.endpoint} ")
-      addHealthEndpoint()
+  internal fun mapRoutes() {
+    // Ensure the user has set the path to root property
+    if (properties.pathToRoot.isEmpty()) {
+      logger.error("Cannot build routes. The 'pathToRoot' property has not been set.")
+      return
     }
+
+    val startTime = LocalDateTime.now()
 
     val routes = getRoutes()
+    val routeCount = processRoutes(routes)
 
-    val routeHandlers = routes.map {
-      RouteHandler(
-        it.value,
-        it.value::class.qualifiedName!!.toPath(it.value::class.simpleName!!)
-      )
-    }.filter { it.path.contains(properties.pathToPackage) }
-
-    logger.info("Discovered ${routeHandlers.size} possible routes.")
-
-    // Routes with an overridden path must be handled differently
-    val overrideRoutes = routeHandlers.filter {
-      !(it.handlerInstance::class.findAnnotation<Route>()?.path.isNullOrEmpty()) ||
-        !(it.handlerInstance::class.findAnnotation<RouteController>()?.path.isNullOrEmpty())
-    }
-
-    logger.info("Found ${overrideRoutes.size} routes with overridden paths.")
-
-    overrideRoutes.forEach { processRouteHandlerWithOverride(it) }
-
-    val normalRoutes = routeHandlers - overrideRoutes
-
-    normalRoutes.sortRoutes().forEach { processRouteHandler(it) }
-    routesReady = true
-
-    // Clear the path cache because it's not needed anymore
-    pathCache.clear()
-    // logger.info("$mappedRoutes routes have been mapped.")
+    val timeSpent = Duration.between(startTime, LocalDateTime.now())
+    logger.info("Took ${timeSpent.toMillis()} ms to map $routeCount routes.")
   }
 
   private fun getRoutes(): Map<String, Any> {
     return context.getBeansWithAnnotation(Route::class.java) + context.getBeansWithAnnotation(RouteController::class.java)
   }
 
-  private fun processRouteHandler(routeHandler: RouteHandler) {
+  private fun processRoutes(routes: Map<String, Any>): Int {
+    val routeHandlers = routes.toRouteHandlers(properties.pathToRoot)
+
+    logger.info("Discovered ${routeHandlers.size} possible routes.")
+
+    // Routes with an overridden path must be handled differently
+    val normalRoutes = processRouteHandlersWithOverride(routeHandlers)
+
+    // Process everything else
+    processRouteHandlers(normalRoutes)
+
+    return routeHandlers.size
+  }
+
+  private fun getRoutesWithOverride(routes: List<RouteHandler>) =
+    routes.filter {
+      !(it.handlerInstance::class.findAnnotation<Route>()?.path.isNullOrEmpty()) ||
+        !(it.handlerInstance::class.findAnnotation<RouteController>()?.path.isNullOrEmpty())
+    }
+
+  private fun processRouteHandlersWithOverride(routes: List<RouteHandler>): List<RouteHandler> {
+    val overrideRoutes = getRoutesWithOverride(routes)
+
+    logger.info("Found ${overrideRoutes.size} routes with overridden paths.")
+
+    overrideRoutes.forEach { processRouteHandler(it, true) }
+
+    return routes - overrideRoutes
+  }
+
+  private fun processRouteHandler(routeHandler: RouteHandler, override: Boolean = false) {
     // get all route handler functions
     val requestMethodHandlers = routeHandler.handlerInstance::class.functions.filter {
       it.name == "handler" ||
         it.name.ofRequestMethod(true) != null ||
-        (
-          it.hasAnnotation<Get>() ||
-            it.hasAnnotation<Post>() ||
-            it.hasAnnotation<Put>() ||
-            it.hasAnnotation<Delete>()
-          )
+        it.hasRequestAnnotation()
     }
-
-    if (requestMethodHandlers.isEmpty()) return
 
     // We only need to build a path using the first function because they should all have the same route
-    val path = getOrCachePath(routeHandler.path, requestMethodHandlers.first())
-
-    requestMethodHandlers.forEach {
-      val requestMethod = when {
-        it.name == "handler" -> {
-          routeHandler.handlerInstance::class.simpleName!!.ofRequestMethod()
-        }
-        it.name.ofRequestMethod(true) != null -> {
-          it.name.ofRequestMethod(true)
-        }
-        else -> {
-          it.annotations.findRequestMethodAnnotation()
-        }
-      }
-
-      val producesConsumes = it.findAnnotation<Get>()?.let { annotation ->
-        Pair(annotation.produces, annotation.consumes)
-      } ?: it.findAnnotation<Post>()?.let { annotation ->
-        Pair(annotation.produces, annotation.consumes)
-      } ?: it.findAnnotation<Put>()?.let { annotation ->
-        Pair(annotation.produces, annotation.consumes)
-      } ?: it.findAnnotation<Delete>()?.let { annotation ->
-        Pair(annotation.produces, annotation.consumes)
-      }
-
-      val produces = producesConsumes?.first
-      val consumes = producesConsumes?.second
-
-      val routeOptions = RouteOptions(
-        path,
-        requestMethod!!,
-        produces ?: MediaType.APPLICATION_JSON_VALUE,
-        consumes ?: ""
-      )
-      mapRoute(routeHandler.handlerInstance, it.javaMethod!!, routeOptions)
-    }
-  }
-
-  private fun getOrCachePath(originalPath: String, handlerFunction: KFunction<*>): String {
-    var setPath = originalPath
-    /*
-          Get all the names of path variables in the route handler.
-          Spring allows the user to specify a name or value instead of the parameter name for mapping purposes
-          so we have to check if those are set
-         */
-    val routePathVariables: List<String> = handlerFunction.parameters.mapNotNull { parameter ->
-      parameter.findAnnotation<PathVariable>()?.let { pathVariable ->
-        when {
-          pathVariable.name.isNotEmpty() -> pathVariable.name
-          pathVariable.value.isNotEmpty() -> pathVariable.value
-          else -> parameter.name
-        }
-      }
-    }
-
-    setPath = setPath.toKebabCase()
-
-    /*
-      Check if there is a path already for the original path (folder path)
-      that also includes the same path variables
-     */
-    val matchingPathInfo = pathCache.firstOrNull { pathInfo ->
-      setPath.contains(pathInfo.originalPath.toKebabCase()) && routePathVariables.containsAll(pathInfo.pathVariables)
-    }
-
-    if (matchingPathInfo != null) {
-      setPath = setPath.replace(matchingPathInfo.originalPath, matchingPathInfo.newPath)
-      // It's possible the user has additional path variables than the matching cached path
-      val missingPathVariables = routePathVariables - matchingPathInfo.pathVariables
-
-      if (missingPathVariables.isNotEmpty()) {
-        var pathToAppend = ""
-
-        // If there are any path variables not found in the matched info,
-        // then they must be appended to the path
-        missingPathVariables.forEach { pathVariable ->
-          pathToAppend += "/{$pathVariable}"
-        }
-
-        setPath += pathToAppend
-
-        // This path must be cached since it has additional path variables
-        pathCache.add(PathInfo(matchingPathInfo.originalPath, setPath, routePathVariables))
-      } else {
-        // This route's path and path variables are the same as another so we do not cache again.
-        setPath = matchingPathInfo.newPath
-      }
-    } else {
-      // We did not find an existing path, so this one is new and must be cached.
-      var pathToAppend = ""
-
-      routePathVariables.forEach { pathVariable ->
-        pathToAppend += "/{$pathVariable}"
-      }
-      val newPath = setPath + pathToAppend
-
-      // if no matching path then this is a new path
-      pathCache.add(PathInfo(setPath, newPath, routePathVariables))
-
-      setPath = newPath
-    }
-
-    return setPath.removeRootPathFromPath(properties.pathToPackage)
-  }
-
-  private fun processRouteHandlerWithOverride(routeHandler: RouteHandler) {
-    // get all route handler functions
-    val requestMethodHandlers = routeHandler.handlerInstance::class.functions.filter {
-      it.name == "handler" ||
-        (
-          it.hasAnnotation<Get>() ||
-            it.hasAnnotation<Post>() ||
-            it.hasAnnotation<Put>() ||
-            it.hasAnnotation<Delete>()
-          )
-    }
-
-    requestMethodHandlers.forEach {
-      val requestMethod = when {
-        it.name == "handler" -> {
-          routeHandler.handlerInstance::class.simpleName!!.ofRequestMethod()
-        }
-        it.name.ofRequestMethod(true) != null -> {
-          it.name.ofRequestMethod(true)
-        }
-        else -> {
-          it.annotations.findRequestMethodAnnotation()
-        }
-      }
-
-      val overridePath = routeHandler.handlerInstance::class.findAnnotation<Route>()?.path
+    val path = if (override) {
+      routeHandler.handlerInstance::class.findAnnotation<Route>()?.path
         ?: routeHandler.handlerInstance::class.findAnnotation<RouteController>()?.path
+    } else {
+      pathCache.getOrCache(routeHandler.path, requestMethodHandlers.first())
+    }
 
-      val producesConsumes = it.findAnnotation<Get>()?.let { annotation ->
-        Pair(annotation.produces, annotation.consumes)
-      } ?: it.findAnnotation<Post>()?.let { annotation ->
-        Pair(annotation.produces, annotation.consumes)
-      } ?: it.findAnnotation<Put>()?.let { annotation ->
-        Pair(annotation.produces, annotation.consumes)
-      } ?: it.findAnnotation<Delete>()?.let { annotation ->
-        Pair(annotation.produces, annotation.consumes)
-      }
+    if (path != null) {
+      requestMethodHandlers.forEach {
+        val requestMethod = when {
+          it.name == "handler" -> {
+            routeHandler.handlerInstance::class.simpleName!!.ofRequestMethod()
+          }
+          it.name.ofRequestMethod(true) != null -> {
+            it.name.ofRequestMethod(true)
+          }
+          else -> {
+            it.annotations.findRequestMethodAnnotation()
+          }
+        }
 
-      if (overridePath != null) {
+        val producesConsumes = it.getProducesConsumes()
+
         val routeOptions = RouteOptions(
-          overridePath,
+          path,
           requestMethod!!,
           producesConsumes?.first ?: MediaType.APPLICATION_JSON_VALUE,
           producesConsumes?.second ?: ""
         )
         mapRoute(routeHandler.handlerInstance, it.javaMethod!!, routeOptions)
       }
-      // TODO else Log bad route
     }
+  }
+
+  private fun processRouteHandlers(routes: List<RouteHandler>) {
+    routes.sortRoutes().forEach { processRouteHandler(it) }
   }
 
   private fun mapRoute(
@@ -271,26 +141,4 @@ class RouteMapper(
       routeHandlerFunction
     )
   }
-
-  private fun addHealthEndpoint() {
-
-    val handlerFunction = this::class.java.declaredMethods.firstOrNull {
-      it.name == "healthk"
-    } ?: return
-
-    val requestMappingInfo = RequestMappingInfo
-      .paths("/${properties.health.endpoint}")
-      .methods(RequestMethod.GET)
-      .produces(MediaType.APPLICATION_JSON_VALUE)
-
-    handlerMapping.registerMapping(
-      requestMappingInfo.build(),
-      this,
-      handlerFunction
-    )
-  }
-
-  // Default health endpoint. This is configured last to ensure all routes have been mapped.
-  fun healthk(): ResponseEntity<Unit> =
-    if (routesReady) ResponseEntity(HttpStatus.OK) else ResponseEntity(HttpStatus.SERVICE_UNAVAILABLE)
 }

--- a/kleuth/src/main/kotlin/io/alienhead/kleuth/RouteOptions.kt
+++ b/kleuth/src/main/kotlin/io/alienhead/kleuth/RouteOptions.kt
@@ -3,7 +3,7 @@ package io.alienhead.kleuth
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.RequestMethod
 
-data class RouteOptions(
+internal data class RouteOptions(
   val path: String,
   val method: RequestMethod,
   val produces: String = MediaType.APPLICATION_JSON_VALUE,

--- a/kleuth/src/main/kotlin/io/alienhead/kleuth/config/KleuthProperties.kt
+++ b/kleuth/src/main/kotlin/io/alienhead/kleuth/config/KleuthProperties.kt
@@ -10,7 +10,7 @@ class KleuthProperties(
   /**
    *
    */
-  val pathToPackage: String = "",
+  val pathToRoot: String = "",
   /**
    *
    */


### PR DESCRIPTION
### Added
- Log statement to show how long Kleuth took to map all the routes. Impressive performance numbers. About ~3 ms for each route. Even a "large" microservice with 100 routes would take about 300 ms. This shows Kleuth has virtually no performance impact considering Spring can take 10 seconds to start.

### Changed
- Moved around a lot of the mapping code to better organize. Somehow increased performance too.
- Internalized all of the code the user won't touch.
- Renamed `pathToPackage` property to `pathToRoot`
### Removed
- Health endpoint. The app will not start until Kleuth is finished mapping routes. Also kleuth finishes with virtually no latency.