### PR TITLE
Content annotation

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,3 +12,7 @@ repositories {
 configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {
   disabledRules.set(setOf("final-newline"))
 }
+
+tasks.build {
+  dependsOn("ktlintFormat")
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,7 +12,3 @@ repositories {
 configure<org.jlleitschuh.gradle.ktlint.KtlintExtension> {
   disabledRules.set(setOf("final-newline"))
 }
-
-tasks.build {
-  dependsOn("ktlintFormat")
-}

--- a/documentation/docs/content-type.md
+++ b/documentation/docs/content-type.md
@@ -3,10 +3,21 @@ title: Content Type
 slug: /framework/content-type
 ---
 
-Kleuth defaults the `produces` and `consumes` attributes of a request mapping to JSON. If you need to override this behavior, say, to consume a CSV file,
-the request method annotations (`Get`, `Post`, etc.) provide the option to set custom `produces` and `consumes` attributes.
+Kleuth defaults the `produces` and `consumes` attributes of a request mapping to JSON (depending on HTTP method). If you need to override this behavior, say, to consume a CSV file,
+there are different options. This mirrors Spring's content setting.
 
-This is just like what needs to be done on a Spring `RequestMapping` function.
+The `Content` annotation provides this functionality for handler and function name routing styles.
+```kotlin
+@Route
+class Csv {
+    @Content(consumes = "text/csv")
+    fun handler( /* ... */ ) {
+        // ...
+    }
+}
+```
+
+The request method annotations (`Get`, `Post`, etc.) provide the option to set custom `produces` and `consumes` attributes.
 
 ```kotlin
 @Post(consumes = "text/csv")

--- a/kleuth-framework/build.gradle.kts
+++ b/kleuth-framework/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
 }
 
 group = "io.alienhead.kleuth"
-version = "1.0.2"
+version = "1.1.0"
 
 java.sourceCompatibility = JavaVersion.VERSION_1_8
 
@@ -72,7 +72,7 @@ publishing {
     create<MavenPublication>("mavenJava") {
       groupId = "io.alienhead.kleuth"
       artifactId = "kleuth-framework"
-      version = "1.0.2"
+      version = "1.1.0"
 
       from(components["java"])
       artifact(tasks.getAt("dokkaJar"))

--- a/kleuth-framework/src/main/kotlin/io/alienhead/kleuth/annotations/request/Content.kt
+++ b/kleuth-framework/src/main/kotlin/io/alienhead/kleuth/annotations/request/Content.kt
@@ -1,0 +1,18 @@
+package io.alienhead.kleuth.annotations.request
+
+import org.springframework.http.MediaType
+
+/**
+ * Used to denote the produce and consumes content types for the route.
+ *
+ * @param produces Used to override the default produces value for the request mapping
+ * @param consumes Used to override the default consumes value for the request mapping
+ *
+ * @see Route
+ */
+@Target(AnnotationTarget.FUNCTION)
+@Retention
+annotation class Content(
+  val produces: String = MediaType.APPLICATION_JSON_VALUE,
+  val consumes: String = ""
+)

--- a/kleuth-framework/src/main/kotlin/io/alienhead/kleuth/annotations/routing/RequestMethod.kt
+++ b/kleuth-framework/src/main/kotlin/io/alienhead/kleuth/annotations/routing/RequestMethod.kt
@@ -1,4 +1,4 @@
-package io.alienhead.kleuth.annotations
+package io.alienhead.kleuth.annotations.routing
 
 /**
  * Used to denote a class as a Kleuth route when the class name is an http request method (Get, Post, Put).

--- a/kleuth-framework/src/main/kotlin/io/alienhead/kleuth/annotations/routing/Route.kt
+++ b/kleuth-framework/src/main/kotlin/io/alienhead/kleuth/annotations/routing/Route.kt
@@ -1,4 +1,4 @@
-package io.alienhead.kleuth.annotations
+package io.alienhead.kleuth.annotations.routing
 
 import org.springframework.web.bind.annotation.RestController
 

--- a/kleuth-framework/src/main/kotlin/io/alienhead/kleuth/mapper/RouteMapper.kt
+++ b/kleuth-framework/src/main/kotlin/io/alienhead/kleuth/mapper/RouteMapper.kt
@@ -1,7 +1,7 @@
 package io.alienhead.kleuth.mapper
 
-import io.alienhead.kleuth.annotations.RequestMethod
-import io.alienhead.kleuth.annotations.Route
+import io.alienhead.kleuth.annotations.routing.RequestMethod
+import io.alienhead.kleuth.annotations.routing.Route
 import io.alienhead.kleuth.config.KleuthProperties
 import io.alienhead.kleuth.utils.findRequestMethodAnnotation
 import io.alienhead.kleuth.utils.getProducesConsumes

--- a/kleuth-framework/src/main/kotlin/io/alienhead/kleuth/utils/ParsingUtils.kt
+++ b/kleuth-framework/src/main/kotlin/io/alienhead/kleuth/utils/ParsingUtils.kt
@@ -1,5 +1,6 @@
 package io.alienhead.kleuth.utils
 
+import io.alienhead.kleuth.annotations.request.Content
 import io.alienhead.kleuth.annotations.request.Delete
 import io.alienhead.kleuth.annotations.request.Get
 import io.alienhead.kleuth.annotations.request.Post
@@ -61,7 +62,9 @@ internal fun String.ofRequestMethod(strictEquality: Boolean = false): RequestMet
  * Gets the produces and consumes values if they are set on the Request Method Annotation
  */
 internal fun KFunction<*>.getProducesConsumes() =
-  this.findAnnotation<Get>()?.let { annotation ->
+  this.findAnnotation<Content>()?.let { annotation ->
+    Pair(annotation.produces, annotation.consumes)
+  } ?: this.findAnnotation<Get>()?.let { annotation ->
     Pair(annotation.produces, annotation.consumes)
   } ?: this.findAnnotation<Post>()?.let { annotation ->
     Pair(annotation.produces, annotation.consumes)

--- a/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/camelCase/GetCamelCase.kt
+++ b/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/camelCase/GetCamelCase.kt
@@ -1,6 +1,6 @@
 package io.alienhead.kleuth.routes.api.camelCase
 
-import io.alienhead.kleuth.annotations.Route
+import io.alienhead.kleuth.annotations.routing.Route
 import io.alienhead.kleuth.resource.TestResource
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable

--- a/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/camelCase/childWithCamelCase/GetChildWithCamelCaseEverything.kt
+++ b/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/camelCase/childWithCamelCase/GetChildWithCamelCaseEverything.kt
@@ -1,6 +1,6 @@
 package io.alienhead.kleuth.routes.api.camelCase.childWithCamelCase
 
-import io.alienhead.kleuth.annotations.Route
+import io.alienhead.kleuth.annotations.routing.Route
 import io.alienhead.kleuth.resource.TestResource
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable

--- a/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/consumes/PostConsumes.kt
+++ b/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/consumes/PostConsumes.kt
@@ -1,7 +1,7 @@
 package io.alienhead.kleuth.routes.api.consumes
 
-import io.alienhead.kleuth.annotations.Route
 import io.alienhead.kleuth.annotations.request.Post
+import io.alienhead.kleuth.annotations.routing.Route
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RequestBody
 

--- a/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/content/GetConsumes.kt
+++ b/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/content/GetConsumes.kt
@@ -1,0 +1,13 @@
+package io.alienhead.kleuth.routes.api.content
+
+import io.alienhead.kleuth.annotations.request.Content
+import io.alienhead.kleuth.annotations.routing.Route
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.RequestBody
+
+@Route
+class GetConsumes {
+
+  @Content(consumes = "text/plain")
+  fun handler(@RequestBody body: String): ResponseEntity<String> = ResponseEntity.ok(body)
+}

--- a/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/delete/ResourceDeleteRoute.kt
+++ b/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/delete/ResourceDeleteRoute.kt
@@ -1,6 +1,6 @@
 package io.alienhead.kleuth.routes.api.delete
 
-import io.alienhead.kleuth.annotations.Route
+import io.alienhead.kleuth.annotations.routing.Route
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable
 

--- a/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/multiple/GetMultipleHandlers.kt
+++ b/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/multiple/GetMultipleHandlers.kt
@@ -1,7 +1,7 @@
 package io.alienhead.kleuth.routes.api.multiple
 
-import io.alienhead.kleuth.annotations.Route
 import io.alienhead.kleuth.annotations.request.Post
+import io.alienhead.kleuth.annotations.routing.Route
 import io.alienhead.kleuth.resource.TestResource
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.RequestBody

--- a/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/override/other/GetWithOverriddenPath.kt
+++ b/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/override/other/GetWithOverriddenPath.kt
@@ -1,6 +1,6 @@
 package io.alienhead.kleuth.routes.api.override.other
 
-import io.alienhead.kleuth.annotations.Route
+import io.alienhead.kleuth.annotations.routing.Route
 import io.alienhead.kleuth.resource.TestResource
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable

--- a/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/override/other/GetWithOverriddenPathOther.kt
+++ b/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/override/other/GetWithOverriddenPathOther.kt
@@ -1,6 +1,6 @@
 package io.alienhead.kleuth.routes.api.override.other
 
-import io.alienhead.kleuth.annotations.RequestMethod
+import io.alienhead.kleuth.annotations.routing.RequestMethod
 import io.alienhead.kleuth.resource.TestResource
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable

--- a/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/pathVariables/GetTestRootPathVariable.kt
+++ b/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/pathVariables/GetTestRootPathVariable.kt
@@ -1,6 +1,6 @@
 package io.alienhead.kleuth.routes.api.pathVariables
 
-import io.alienhead.kleuth.annotations.Route
+import io.alienhead.kleuth.annotations.routing.Route
 import io.alienhead.kleuth.resource.TestResource
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable

--- a/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/pathVariables/child/GetChildByIdAndTestId.kt
+++ b/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/pathVariables/child/GetChildByIdAndTestId.kt
@@ -1,6 +1,6 @@
 package io.alienhead.kleuth.routes.api.pathVariables.child
 
-import io.alienhead.kleuth.annotations.Route
+import io.alienhead.kleuth.annotations.routing.Route
 import io.alienhead.kleuth.resource.TestResource
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable

--- a/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/pathVariables/child/GetChildByTestId.kt
+++ b/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/pathVariables/child/GetChildByTestId.kt
@@ -1,6 +1,6 @@
 package io.alienhead.kleuth.routes.api.pathVariables.child
 
-import io.alienhead.kleuth.annotations.Route
+import io.alienhead.kleuth.annotations.routing.Route
 import io.alienhead.kleuth.resource.TestResource
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable

--- a/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/pathVariables/child/nestedChild/GetNestedChild.kt
+++ b/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/pathVariables/child/nestedChild/GetNestedChild.kt
@@ -1,6 +1,6 @@
 package io.alienhead.kleuth.routes.api.pathVariables.child.nestedChild
 
-import io.alienhead.kleuth.annotations.Route
+import io.alienhead.kleuth.annotations.routing.Route
 import io.alienhead.kleuth.resource.TestResource
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable

--- a/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/pathVariables/child/nestedChild/GetNestedChildByIdAndTestIdAndChildId.kt
+++ b/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/pathVariables/child/nestedChild/GetNestedChildByIdAndTestIdAndChildId.kt
@@ -1,6 +1,6 @@
 package io.alienhead.kleuth.routes.api.pathVariables.child.nestedChild
 
-import io.alienhead.kleuth.annotations.Route
+import io.alienhead.kleuth.annotations.routing.Route
 import io.alienhead.kleuth.resource.TestResource
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable

--- a/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/pathVariables/child/nestedChild/PostNestedChild.kt
+++ b/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/pathVariables/child/nestedChild/PostNestedChild.kt
@@ -1,6 +1,6 @@
 package io.alienhead.kleuth.routes.api.pathVariables.child.nestedChild
 
-import io.alienhead.kleuth.annotations.Route
+import io.alienhead.kleuth.annotations.routing.Route
 import io.alienhead.kleuth.resource.TestResource
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable

--- a/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/pathVariables/otherChild/GetOtherChildPathVariable.kt
+++ b/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/pathVariables/otherChild/GetOtherChildPathVariable.kt
@@ -1,6 +1,6 @@
 package io.alienhead.kleuth.routes.api.pathVariables.otherChild
 
-import io.alienhead.kleuth.annotations.Route
+import io.alienhead.kleuth.annotations.routing.Route
 import io.alienhead.kleuth.resource.TestResource
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable

--- a/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/produces/GetProduces.kt
+++ b/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/produces/GetProduces.kt
@@ -1,7 +1,7 @@
 package io.alienhead.kleuth.routes.api.produces
 
-import io.alienhead.kleuth.annotations.Route
 import io.alienhead.kleuth.annotations.request.Get
+import io.alienhead.kleuth.annotations.routing.Route
 import org.apache.commons.csv.CSVFormat
 import org.apache.commons.csv.CSVPrinter
 import org.springframework.core.io.InputStreamResource

--- a/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/separate/GetSeparateHandler.kt
+++ b/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/separate/GetSeparateHandler.kt
@@ -1,6 +1,6 @@
 package io.alienhead.kleuth.routes.api.separate
 
-import io.alienhead.kleuth.annotations.Route
+import io.alienhead.kleuth.annotations.routing.Route
 import io.alienhead.kleuth.resource.TestResource
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable

--- a/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/separate/PostSeparateHandler.kt
+++ b/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/separate/PostSeparateHandler.kt
@@ -1,6 +1,6 @@
 package io.alienhead.kleuth.routes.api.separate
 
-import io.alienhead.kleuth.annotations.Route
+import io.alienhead.kleuth.annotations.routing.Route
 import io.alienhead.kleuth.resource.TestResource
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.PathVariable

--- a/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/single/GetSingleHandler.kt
+++ b/kleuth-integration-tests/src/main/kotlin/io/alienhead/kleuth/routes/api/single/GetSingleHandler.kt
@@ -1,6 +1,6 @@
 package io.alienhead.kleuth.routes.api.single
 
-import io.alienhead.kleuth.annotations.Route
+import io.alienhead.kleuth.annotations.routing.Route
 import io.alienhead.kleuth.resource.TestResource
 import org.springframework.http.ResponseEntity
 

--- a/kleuth-integration-tests/src/test/kotlin/io/alienhead/kleuth/routes/api/EverythingTests.kt
+++ b/kleuth-integration-tests/src/test/kotlin/io/alienhead/kleuth/routes/api/EverythingTests.kt
@@ -174,7 +174,7 @@ class EverythingTests(mvc: MockMvc) : DescribeSpec() {
       }
 
       describe("/consumes") {
-        it("should map get request to handler and override default produces") {
+        it("should map get request to handler and override default consumes") {
           mvc.perform(
             post("/consumes")
               .contentType(MediaType.TEXT_PLAIN)
@@ -195,6 +195,19 @@ class EverythingTests(mvc: MockMvc) : DescribeSpec() {
             .andExpect(status().isOk)
             .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$", `is`("Deleted 1234")))
+        }
+      }
+
+      describe("/content") {
+        it("should map get request to handler and override default consumes") {
+          mvc.perform(
+            get("/content")
+              .contentType(MediaType.TEXT_PLAIN)
+              .content("1234")
+          )
+            .andExpect(status().isOk)
+            .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+            .andExpect(content().string("1234"))
         }
       }
     }


### PR DESCRIPTION
### Changes
* Reorganized routing annotations
* Added `Content` annotation to allow handler and function name routing styles to override the default produce and consume content types for a route.